### PR TITLE
데이터를 받아와서 상세페이지 렌더링 구현/상세페이지 좋아요 기능 연동/상세페이지 캐러셀 기능 구현

### DIFF
--- a/frontend/CSS/item_like_chat_list.css
+++ b/frontend/CSS/item_like_chat_list.css
@@ -68,15 +68,18 @@
 
 .item_sub_func i {
     margin-right: 5%;
+    
+}
+
+.like {
+    color: rgb(204, 62, 62);
+    margin-left: 5%;
     cursor: pointer;
 }
 
-#like, #unlike {
-    color: rgb(204, 62, 62);
-}
-
-#chat {
+.chat {
     color: var(--dark-grey-color);
+    cursor: pointer;
 }
 
 

--- a/frontend/JS/carousel.js
+++ b/frontend/JS/carousel.js
@@ -1,23 +1,22 @@
-// const preBtn = document.querySelector('.prev');
-// const nextBtn = document.querySelector('.next');
-// const carousel = document.querySelector('.carousel');
+export function carouselFunc() {
+    const preBtn = document.querySelector('.prev');
+    const nextBtn = document.querySelector('.next');
+    const carousel = document.querySelector('.carousel');
+    let index = 0; // 사진의 개수만큼
+    preBtn.addEventListener('click', () => {
+        if(index === 0){
+            return;
+        }
+        index -= 1;
 
-// let index = 0; // 사진의 개수만큼
+        carousel.style.transform = `translate3d(-${500 * index}px, 0, 0)`;
+    });
+    nextBtn.addEventListener('click', () => {
+        if(index === 2){ //사진의 개수 -1
+            return;
+        }
+        index += 1;
+        carousel.style.transform = `translate3d(-${500 * index}px, 0, 0)`;
+    });
+}
 
-// preBtn.addEventListener('click', () => {
-//     if(index === 0){
-//         return;
-//     }
-//     index -= 1;
-
-//     carousel.style.transform = `translate3d(-${500 * index}px, 0, 0)`;
-// });
-
-// nextBtn.addEventListener('click', () => {
-//     if(index === 4){ //사진의 개수 -1
-//         return;
-//     }
-//     index += 1;
-
-//     carousel.style.transform = `translate3d(-${500 * index}px, 0, 0)`;
-// });

--- a/frontend/JS/move_to_detail.js
+++ b/frontend/JS/move_to_detail.js
@@ -2,10 +2,30 @@ import pushUrl from "./pushUrl.js";
 import renderingHTML from "./render.js";
 import { getDetailHTML } from "./views/detail_page.js";
 
-
-export function moveToDetail(key) {
-    let url = 'detail' + key;
-    let html_str = getDetailHTML(key);
-    pushUrl(url);
-    renderingHTML(url,html_str);
+export function moveToDetail(key, user_id, like_class) {
+    if(like_class === 'fas'){ // 이미 좋아요 되어있는 상태면 1
+        like_class = 1
+    }else{
+        like_class = 0 // 만약 아니면 0
+    }
+    let url = 'detail'
+    console.log('키와 유저 아이디 ',key, user_id)
+    let item_id = key;
+    $.ajax({
+        type: "POST",
+        url:'/detail',
+        data: {
+            item_id : item_id,
+            user_id : user_id,
+            like_status : like_class
+        },
+        dataType: 'json',
+        success: (response)=>{
+            console.log(response);
+            let html_str = getDetailHTML(response);
+            pushUrl(url);
+            renderingHTML(url,html_str);
+        },
+        error: (log)=>{console.log(log)}
+    });
 }

--- a/frontend/JS/render.js
+++ b/frontend/JS/render.js
@@ -9,6 +9,7 @@ import { checkId } from "./check_id.js";
 import { addLocation } from "./add_location.js";
 import { deleteLocation } from "./delete_location.js";
 import { sendSubFuncData } from "./send_subfun_data.js";
+import { carouselFunc } from "./carousel.js";
 
 const container = document.querySelector('.container');
 
@@ -17,16 +18,21 @@ export default function renderingHTML(url, html_str){
     //만약 url에 detail이라는 문자가 포함되어 있으면 detail page로 이동
     if(url.includes('detail')){
         container.insertAdjacentHTML('afterbegin', html_str);
+        //캐러셀 작동 코드
+        carouselFunc();
+        const like_btns = document.querySelectorAll('.like');
+        like_btns.forEach(btn => btn.addEventListener('click', sendSubFuncData));
     }
     if(url.includes('searched')){
         container.insertAdjacentHTML('afterbegin', html_str);
         //이미지 클릭 시 상세 페이지로 넘어가는 이벤트 등록
         const imgs = document.querySelectorAll('.item_img img');
         imgs.forEach(img => img.addEventListener('click', (e)=>{
-            moveToDetail(e.target.alt);
+            let like_status = e.target.parentNode.parentNode.querySelector('.like').classList[0]
+            moveToDetail(e.target.dataset.key, e.target.dataset.user, like_status);
         }));
         //좋아요, 채팅 클릭 시 DB에 좋아요 등록, 채팅 신청 정보 보내고 해당 페이지 다시 그리기.
-        const like_btns = document.querySelectorAll('#like');
+        const like_btns = document.querySelectorAll('.like');
         like_btns.forEach(btn => btn.addEventListener('click', sendSubFuncData));
     }
     if(url.includes('like_list')){

--- a/frontend/JS/views/detail_page.js
+++ b/frontend/JS/views/detail_page.js
@@ -1,48 +1,54 @@
-export function getDetailHTML(key) {
+export function getDetailHTML(response) {
+    let like = '';
+    if(response[0].like_status === '1'){
+        like = `<i data-key="${response[0].id}" class="fas fa-heart fa-2x like"></i>`;
+    }else {
+        like = `<i data-key="${response[0].id}" class="far fa-heart fa-2x like"></i>`;
+    }
+    let images = response[0].paths.split(',');
     let detail_page_html = 
     `<div class="detail">
-    <div class="detail_header">
-        <button class="prev">＜</button>
-        <div class="carousel-wrapper">
-            <div class="carousel">
-                <img src="imgs/detail_img/1.jpg">
-                <img src="imgs/detail_img/2.jpg">
-                <img src="imgs/detail_img/3.jpg">
-                <img src="imgs/detail_img/4.jpg">
-                <img src="imgs/detail_img/5.jpg">
+        <div class="detail_header">
+            <button class="prev">＜</button>
+            <div class="carousel-wrapper">
+                <div class="carousel">
+                    <img src="${images[0]}">
+                    <img src="${images[1]}">
+                    <img src="${images[2]}">
+                </div>
+            </div>
+            <button class="next">＞</button>
+        </div>
+        <div class="detail_content">
+            <div class="profile_img_box">
+                <img src="${response[0].owner_profile}" alt="" class="detail_img">
+            </div>
+            <div class="profile_info">
+                <div class="profile_info_box">
+                    <span class="profile_title">${response[0].name}</span>
+                    <span class="profile_phone_num">${response[0].phone_num}</span>
+                </div>
+                <div class="profile_sub_func">
+                    <i class="fas fa-comment-dots fa-2x chat"></i>
+                    ${like}
+                </div>   
             </div>
         </div>
-        <button class="next">＞</button>
-    </div>
-    <div class="detail_content">
-        <div class="profile_img_box">
-            <img src="imgs/detail_img/profile.png" alt="" class="detail_img">
-        </div>
-        <div class="profile_info">
-            <div class="profile_info_box">
-                <span class="profile_title">key:${key}인 데이터</span>
-                <span class="profile_phone_num">010-XXXX-XXXX</span>
+        <div class="detail_footer">
+            <span class="detail_footer_title">상세 설명</span>
+            <div class="detail_footer_info">
+                <span>주소: ${response[0].location}</span>
+                <span>보증금: ${response[0].deposit}</span>
+                <span>전/월세: ${response[0].rental_cost}</span>
+                <span>관리비: ${response[0].m_fee}</span>
+                <span>옵션: TV, 냉장고 등</span>
             </div>
-            <div class="profile_sub_func">
-                <i id="chat" class="fas fa-comment-dots fa-2x"></i>
-                <i id="unlike" class="far fa-heart fa-2x"></i>
-            </div>   
+            <div class="detail_footer_chat">
+                <button class="chat_btn">채팅 하기</button>
+            </div>
         </div>
     </div>
-    <div class="detail_footer">
-        <span class="detail_footer_title">상세 설명</span>
-        <div class="detail_footer_info">
-            <span>주소: 우만동 74-1</span>
-            <span>보증금: 5000만원</span>
-            <span>월세: 89만원</span>
-            <span>관리비: 47만원</span>
-            <span>옵션: TV, 냉장고 등</span>
-        </div>
-        <div class="detail_footer_chat">
-            <button class="chat_btn">채팅 하기</button>
-        </div>
-    </div>
-    </div>`;
+    `;
 
     return detail_page_html;
 }

--- a/frontend/JS/views/item_list.js
+++ b/frontend/JS/views/item_list.js
@@ -16,14 +16,15 @@ export function makeItemList(response) {
     let list = '';
     let i = 0;
     while(i < response.length){
+        let image = response[i].paths.split(',');
         if(response[i].like === 1){
-            like = `<i id="like" data-key="${response[i].id}" class="fas fa-heart fa-2x"></i>`;
+            like = `<i data-key="${response[i].id}" class="fas fa-heart fa-2x like"></i>`;
         }else {
-            like = `<i id="like" data-key="${response[i].id}" class="far fa-heart fa-2x"></i>`;
+            like = `<i data-key="${response[i].id}" class="far fa-heart fa-2x like"></i>`;
         }
         list = list + 
         `<li> <div class="item_img">
-        <img src="${response[i].image}" data-key="${response[i].id}">
+        <img src="${image[0]}" data-user="${response[i].user_id}" data-key="${response[i].id}">
         </div>
         <div class="item_info">
             <span>위치: ${response[i].location}</span>
@@ -33,7 +34,7 @@ export function makeItemList(response) {
             <span>부동산: ${response[i].name}</span>
         </div>
         <div class="item_sub_func">
-            <i id="chat" class="fas fa-comment-dots fa-2x"></i>
+            <i class="fas fa-comment-dots fa-2x chat"></i>
             ${like}
         </div></li>`;
         i = i + 1;

--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ app.post('/searched_item', (req, res) => {
         if(err) throw err;
         let user_id = result[0].idUSER;
         let location = req.body.location;
-        let sql = `SELECT id,location,deposit,image,rental_cost,m_fee,name,phone_num,chat,sub_func_list.like,user_id FROM sub_func_list right join sale_item on sub_func_list.sale_item_id = sale_item.id right join owner on sale_item.owner_id = owner.idowner where location='${location}' and (user_id='${user_id}' or user_id is null)`;
+        let sql = `SELECT id,location,paths,deposit,rental_cost,m_fee,name,phone_num,chat,sub_func_list.like,user_id FROM sub_func_list right join sale_item on sub_func_list.sale_item_id = sale_item.id right join owner on sale_item.owner_id = owner.idowner inner join (select sale_item_id , group_concat(path) as paths from images group by sale_item_id) as i on(id = i.sale_item_id) where location='${location}' and (user_id='${user_id}' or user_id is null)`;
         con.query(sql, function(err, result) {
             if(err) throw err;
             //만약 해당 지역의 매물이 없을 때
@@ -126,6 +126,19 @@ app.post('/sub_func', (req, res) => {
                 })
             })
         }
+    })
+})
+
+app.post('/detail', (req, res) => {
+    let item_id = req.body.item_id;
+    let user_id = req.body.user_id;
+    let like_status = req.body.like_status;
+    let sql = `SELECT id, location, deposit, paths, rental_cost, m_fee, name, phone_num, owner_profile FROM sale_item as s inner join (select sale_item_id , group_concat(path) as paths from images group by sale_item_id) as i on(s.id = i.sale_item_id) left join owner on owner_id = idowner where id='${item_id}'
+    `
+    con.query(sql, function(err, result) {
+        if(err) throw err;
+        result[0].like_status = like_status;
+        res.send(result);
     })
 })
 


### PR DESCRIPTION
매물 id를 통해 매물의 데이터가 상세 페이지에 반영되도록 구현했습니다.
상세 페이지에 있는 좋아요 버튼도 검색 페이지의 좋아요 버튼과 연동이 되도록 구현하였고
상세 페이지에 있는 좋아요 버튼도 좋아요 등록, 신청 기능이 작동되도록 구현했습니다.
추가로 상세 페이지에 있는 캐러셀 기능도 구현했습니다.

내일은 채팅 관련 기능과 좋아요 목록, 채팅 목록 페이지에 데이터를 반영하도록 구현하겠습니다.
프로젝트가 공식 일정이 끝나더라도 코드 리뷰해주신 부분들을 참고해서 코드를 더 깔끔하게 다듬고
socket을 이용해 채팅 기능도 구현하겠습니다!

오늘의 개발 일지는 Notion에 적어두었습니다.
https://succulent-fridge-8aa.notion.site/2022-01-27-c29ad130d4fa4db5b07cad0b96735eea